### PR TITLE
Changing 16th note triplets to 8th note triplets in Doxy.

### DIFF
--- a/src/jazz/doxy.mako
+++ b/src/jazz/doxy.mako
@@ -92,15 +92,15 @@
 	}
 	\alternative {
 		{
-			e8 g bes des \times 4/3 { c16 des c } g8 bes | r2 r4 r8 f |
+			e8 g bes des \times 2/3 { c8 des c } g8 bes | r2 r4 r8 f |
 		}
 		{
-			e8 g bes des \times 4/3 { c16 des c } g8 a | r1 |
+			e8 g bes des \times 2/3 { c8 des c } g8 a | r1 |
 		}
 	}
 	%% B part
 	g'4 r8 f~ f r des4~ | des4. g,8 r c4 g8 | des'4 des8 des g,4 c | r2 r4 r8 f, |
 	%% A part
-	bes d bes f bes4 r8 f | bes f bes des r g,4 f8 | e g bes des \times 4/3 { c16 des c } g8 bes | r1 |
+	bes d bes f bes4 r8 f | bes f bes des r g,4 f8 | e g bes des \times 2/3 { c8 des c } g8 bes | r1 |
 }
 % endif


### PR DESCRIPTION
Thanks very much for this excellent resource. When looking at Doxy by Sonny Rollins I noticed the triplets were twice as fast, leaving the bar an 8th note too short. This pull request fixes that.

I'd love to add some full tunes in the future. I'm a bit of a lilypond noob so it'll just be little fixes from me for now!
