### PR TITLE
Problem with compiling on OSX [resolved]

### DIFF
--- a/scripts/mako_book.py
+++ b/scripts/mako_book.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import sys
 import mako.template


### PR DESCRIPTION
I had a dependency issue when trying to compile Openbook on OSX. It ended up being a problem with my environment, but I thought I would report it here in case someone else had the same problem, or knows a more _proper_ solution.

When trying to make the pdfs on my OSX machine, I was getting the following error:

```
doing [out/openbook.ly]
Traceback (most recent call last):
  File "scripts/mako_book.py", line 4, in <module>
    import mako.template
ImportError: No module named mako.template
make: *** [out/openbook.ly] Error 1
```

I checked that I had mako installed (via pip):

```
$pip show mako

---
Name: Mako
Version: 0.8.1
Location: /usr/local/lib/python2.7/site-packages
Requires: MarkupSafe
```

I gave up.
