### PR TITLE
Remove superfluous spaces from table of contents

### DIFF
--- a/src/include/common.makoi
+++ b/src/include/common.makoi
@@ -306,7 +306,7 @@ ${self.clearVars()}
 			if attributes['composer']==attributes['poet']:
 				add=' / '+attributes['composer']
 			else:
-				add=' / '+attributes['composer']+' , '+attributes['poet']
+				add=' / '+attributes['composer']+', '+attributes['poet']
 	attributes['tocname']=attributes['title']+add
 %>
 % if attributes['copyright']=='':


### PR DESCRIPTION
There should not be a space before the comma that separates the composer from
the poet.
