### PR TITLE
Build broken by typesetter feature

### DIFF
--- a/src/israeli/besade_yarok.mako
+++ b/src/israeli/besade_yarok.mako
@@ -13,7 +13,7 @@
 	attributes['poet']=u"מאיר אריאל"
 	attributes['singer']=u"דני סנדרסון"
 	attributes['piece']=u"בלדה איטית"
-	atttibutes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
+	attributes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
 
 	attributes['completion']="4"
 	attributes['uuid']="42424480-a26f-11df-abb4-0019d11e5a41"

--- a/src/israeli/eich_hu_shar.mako
+++ b/src/israeli/eich_hu_shar.mako
@@ -14,7 +14,7 @@
 	attributes['poet']=u"דני רובס"
 	attributes['singer']=u"דני רובס"
 	attributes['piece']=u"בלדת רוק"
-	atttibutes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
+	attributes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
 
 	attributes['completion']="5"
 	attributes['uuid']="8203d67e-41a0-11e2-a975-5a1faa0d3cc5"

--- a/src/israeli/eich_ze_shekochav.mako
+++ b/src/israeli/eich_ze_shekochav.mako
@@ -13,7 +13,7 @@
 	attributes['poet']=u"נתן זך"
 	attributes['singer']=u"מתי כספי"
 	attributes['piece']=u"בוסה נובה"
-	atttibutes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
+	attributes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
 
 	attributes['completion']="5"
 	attributes['uuid']="d936b39a-971e-11e0-9c44-0019d11e5a41"

--- a/src/israeli/elohim_shely.mako
+++ b/src/israeli/elohim_shely.mako
@@ -14,7 +14,7 @@
 	attributes['singer']=u"עוזי חיטמן"
 	attributes['piece']=u"בלדה מתונה"
 	attributes['arranger']=u"יאיר רוזנבלום"
-	atttibutes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
+	attributes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
 
 	attributes['completion']="2"
 	attributes['uuid']="467b2af8-a26f-11df-b03d-0019d11e5a41"

--- a/src/israeli/geshem.mako
+++ b/src/israeli/geshem.mako
@@ -14,7 +14,7 @@
 	attributes['poet']=u"יעקב גלעד"
 	attributes['singer']=u"אלי לוזון"
 	attributes['piece']=u"בלדת רוק"
-	atttibutes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
+	attributes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
 
 	attributes['completion']="5"
 	attributes['uuid']="c562b5fa-c345-11e0-995c-0019d11e5a41"

--- a/src/israeli/halilach.mako
+++ b/src/israeli/halilach.mako
@@ -10,7 +10,7 @@
 	attributes['title']=u"כמה יפה פורח הלילך"
 	attributes['style']="Israeli"
 	attributes['piece']=u"בלדה מתונה"
-	atttibutes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
+	attributes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
 
 	attributes['completion']="2"
 	attributes['uuid']="4ae1d01a-a26f-11df-8e51-0019d11e5a41"

--- a/src/israeli/hardufim.mako
+++ b/src/israeli/hardufim.mako
@@ -14,7 +14,7 @@
 	attributes['poet']=u"נתן יונתן"
 	attributes['singer']=u"שלמה ראצי"
 	attributes['piece']=u"שירי ארץ ישראל"
-	atttibutes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
+	attributes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
 
 	attributes['completion']="5"
 	attributes['uuid']="95e9e525-ef27-4e45-bba0-9ba1391723c1"

--- a/src/israeli/he_hazra_betshuva.mako
+++ b/src/israeli/he_hazra_betshuva.mako
@@ -13,7 +13,7 @@
 	attributes['poet']=u"יעקב רוטבליט"
 	attributes['singer']=u"מתי כספי"
 	attributes['piece']=u"בוסה נובה"
-	atttibutes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
+	attributes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
 
 	attributes['completion']="5"
 	attributes['uuid']="24815072-2a71-11e1-a41f-0019d11e5a41"

--- a/src/israeli/kama_ahava.mako
+++ b/src/israeli/kama_ahava.mako
@@ -18,7 +18,7 @@
 	attributes['singer']=u"מאיר בנאי"
 	# mine
 	attributes['piece']=u"פלמנקו"
-	atttibutes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
+	attributes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
 
 	attributes['completion']="4"
 	attributes['uuid']="9196fc14-f623-11e2-afd9-ebf7136455e5"

--- a/src/israeli/lo_yacholti_laasot_klum.mako
+++ b/src/israeli/lo_yacholti_laasot_klum.mako
@@ -14,7 +14,7 @@
 	attributes['poet']=u"יונה וולך"
 	attributes['singer']=u"איןך ןירצברג"
 	attributes['piece']=u"בלדת רוק"
-	atttibutes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
+	attributes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
 
 	attributes['completion']="5"
 	attributes['uuid']="f2e3c22e-f100-11e0-9162-0019d11e5a41"

--- a/src/israeli/noah.mako
+++ b/src/israeli/noah.mako
@@ -18,7 +18,7 @@
 	attributes['singer']=u"מתי כספי"
 	# mine
 	attributes['piece']=u"סמבה"
-	atttibutes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
+	attributes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
 
 	attributes['completion']="5"
 	attributes['uuid']="702eab24-e8ce-11e2-91c8-5b1ff4f22893"

--- a/src/israeli/od_hozer_hanigun.mako
+++ b/src/israeli/od_hozer_hanigun.mako
@@ -9,7 +9,7 @@
 	attributes['style']="Israeli"
 	attributes['singer']=u"ברי סחרוף"
 	attributes['piece']=u"בלדה מתונה"
-	atttibutes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
+	attributes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
 
 	attributes['completion']="0"
 	attributes['uuid']="505a0a3a-a26f-11df-bbef-0019d11e5a41"

--- a/src/israeli/shir_hahed.mako
+++ b/src/israeli/shir_hahed.mako
@@ -13,7 +13,7 @@
 	attributes['poet']=u"יעקב שבתאי"
 	attributes['singer']=u"אריק לביא"
 	attributes['piece']=u"בלדה איטית"
-	atttibutes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
+	attributes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
 
 	attributes['completion']="4"
 	attributes['uuid']="56513346-a26f-11df-b591-0019d11e5a41"

--- a/src/israeli/slihot.mako
+++ b/src/israeli/slihot.mako
@@ -15,7 +15,7 @@
 	attributes['poet']=u"לאה גולדברג"
 	attributes['singer']=u"יהודית רביץ"
 	attributes['piece']=u"בלדה מתונה"
-	atttibutes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
+	attributes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
 
 	attributes['completion']="5"
 	attributes['uuid']="11ad0c38-6dc9-4318-873f-5e7e80b7c8a8"

--- a/src/israeli/yom_shishi_at_yodaat.mako
+++ b/src/israeli/yom_shishi_at_yodaat.mako
@@ -14,7 +14,7 @@
 	attributes['poet']=u"יעקב גלעד"
 	attributes['singer']=u"יהודה פוליקר"
 	attributes['piece']=u"רוקנרול"
-	atttibutes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
+	attributes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
 
 	attributes['completion']="5"
 	attributes['uuid']="d4c79db6-8aec-11e1-bca8-3b15b6cb5cfe"

--- a/src/israeli/zarot_gdolot.mako
+++ b/src/israeli/zarot_gdolot.mako
@@ -13,7 +13,7 @@
 	attributes['poet']=u"שמרית אור"
 	attributes['singer']=u"שלום חנוך"
 	attributes['piece']=u"בלדה מתונה"
-	atttibutes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
+	attributes['typesetter']=u"מרק ולצר <mark.veltzer@gmail.com>"
 
 	attributes['completion']="0"
 	attributes['uuid']="5a9b270e-a26f-11df-a792-0019d11e5a41"


### PR DESCRIPTION
Something in commit 1e3b5f83716eed5fd408b975bb5d54c50740c186 broke my build. It was building the jazz book fine, but then I get the following:

```
$make
doing [out/israelisongbook.ly]
Traceback (most recent call last):
  File "scripts/mako_book.py", line 70, in <module>
    raise e
TypeError: 'Undefined' object does not support item assignment
make: *** [out/israelisongbook.ly] Error 1
```

I noticed a misspelling in the typesetter lines you added to the Israeli pieces so I corrected these (see pull request) and then the Israeli book built successfully, however then the rock book failed:

```
$make
doing [out/israelisongbook.ly]
doing [out/israelisongbook.ps]
doing [out/rockbook.ly]
Traceback (most recent call last):
  File "scripts/mako_book.py", line 70, in <module>
    raise e
KeyError: 'typesetter'
make: *** [out/rockbook.ly] Error 1
```

I assumed that was because the rock numbers don't have typesetter attributes, however I tried adding a typesetter line to `aint_no_sunshine.mako` and got the following error:

```
$make
doing [out/rockbook.ly]
Traceback (most recent call last):
  File "scripts/mako_book.py", line 70, in <module>
    raise e
mako.exceptions.SyntaxException: (IndentationError) unexpected indent (<unknown>, line 9) (u"attributes['doGuitar']=True\nattributes['doOwn']=Tr") in file 'src/rock/aint_no_sunshine.mako' at line: 3 char: 1
make: *** [out/rockbook.ly] Error 1
```
