### PR TITLE
"Build Machine" on cover is too long when compiled on OSX

### DIFF
--- a/src/include/common.makoi
+++ b/src/include/common.makoi
@@ -19,7 +19,7 @@
 	attributes['gitdesc']=subprocess.check_output(['git','describe','--tags']).strip()
 	attributes['gitcommits']=subprocess.check_output(['git','log','--pretty=format:\'\'']).split('\n').__len__()
 	attributes['hostname']=socket.gethostname()
-	attributes['machine']=' '.join(os.uname())
+	attributes['machine']=os.uname()[0]+' '+os.uname()[2]
 %>
 \version "${attributes['lilyver']}"
 


### PR DESCRIPTION
When I compile the book on my OSX machine, the Build Machine note on the cover is too long to fit on the page:

![screen shot 2013-08-11 at 7 37 04 pm](https://f.cloud.github.com/assets/162735/945153/53bda262-02f8-11e3-9daa-1f91056ae689.png)

From looking at the code, that line is a concatenation of five different values [(sysname, nodename, release, version, machine)](http://docs.python.org/2/library/os.html#os.uname). I would propose we either omit some of the values, or split them up into two or more lines.

If you let me know which solution you prefer (and how you want to handle each field). I can write the pull request.
