### PR TITLE
Remove spaces before ? in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 Hello and welcome to OpenBook
 =============================
 
-What is OpenBook ?
+What is OpenBook?
 ------------------
 OpenBook is a Jazz real book constructed with free software. A real book simply means a big book with lots of Jazz tunes or standards as they are more widely known.
 
-Where is the projects website ?
+Where is the projects website?
 -------------------------------
 http://veltzer.net/openbook/
 
-Why did you start this ?
+Why did you start this?
 ------------------------
 Because of many reasons:
 * I wanted to learn Jazz and a good way to do that is to write down the tunes (amongst many many other things).
@@ -20,11 +20,11 @@ Because of many reasons:
 * Jazz musicians may need beautiful electronic Real books because electronic books are starting to be
 used by Jazz musicians both for practice and for performance.
 
-What tools are used ?
+What tools are used?
 ---------------------
 lilypond, make, perl, python, mako, lame, timidity and possibly more.
 
-What is produced ?
+What is produced?
 ------------------
 Beautiful and lightweight postscript and PDF real books with Jazz tunes.
 The idea is that the end user can control the final output and decide if he/she
@@ -32,52 +32,52 @@ wants lyrics, size of paper, transposition for trumpet, selection of tunes and m
 In addition you can produce midi, mp3 and ogg outputs.
 Possibly other output formats will be supported in the future (epub?).
 
-What is the copyright ?
+What is the copyright?
 -----------------------
 All the stuff in this project is GPL version 3. The tunes themselves have their own copyright holders.
 
-Who can contribute ?
+Who can contribute?
 --------------------
 Anyone.
 
-What system do I need to participate ?
+What system do I need to participate?
 --------------------------------------
 A Linux system that you can install software on.
 Windows is not currently supported although well formed patches will be accepted.
 
-What do I need to know to participate ?
+What do I need to know to participate?
 ---------------------------------------
 * Some rudimentary Linux system administration (in order to install the software needed for this project to build).
 * Some basic git software content tracking (in order to fetch the project, modify and submit patches). 
 * The lilypond language (in order to edit or add tunes).
 * Some music knowledge would also help...:)
 
-Who currently contributes ?
+Who currently contributes?
 ---------------------------
 Just me (Mark Veltzer <mark.veltzer@gmail.com>).
 
-Where can I see some results ?
+Where can I see some results?
 ------------------------------
 Check out the PDFs and other outputs in http://veltzer.net/openbook/.
 
-Why is there so little documentation ?
+Why is there so little documentation?
 --------------------------------------
 I just started this project. Feel free to add stuff and request a pull. If you contribute a lot I will make you an admin...
 
-How do you write the standards ?
+How do you write the standards?
 --------------------------------
 Using lilypond. Check it out at: http://www.lilypond.org/
 
-Will you co-operate with the lilypond, mutopia and wikifonia communities ?
+Will you co-operate with the lilypond, mutopia and wikifonia communities?
 --------------------------------------------------------------------------
 YES! Any bugs or feature suggestion are submitted to the lilypond community. Any requests for pieces from the mutopia community will be respected.
 Wikifonia uses musicXML for typesetting while I use an essentially lilypond format as input format - so there could not be much co-operation there.
 
-Do you only allow Jazz tunes ?
+Do you only allow Jazz tunes?
 ------------------------------
 No. Rock and Pop will be welcome and so would classical. If you are really into classical lilypond production you may alternativly wish to contribute to the mutopia project at http://www.mutopiaproject.org/.
 
-How do I get started ?
+How do I get started?
 ----------------------
 * create an account on git hub.
 * git checkout -b [your branch name] git://github.com/veltzer/openbook.git
@@ -87,7 +87,7 @@ How do I get started ?
 * push to git hub (git push).
 * request me to pull your changes (button in the github ui).
 
-Can I just add a single tune ?
+Can I just add a single tune?
 ------------------------------
 Yes. To add a tune named "yourtune" just a single file named
 

--- a/doc/TODO.txt
+++ b/doc/TODO.txt
@@ -121,7 +121,7 @@ config system:
 The system will allow users to config which type of tune they want to produce.
 They could select:
 - scale (C for concert, Bb, Eb for horns etc).
-- do they want lyrics ?
+- do they want lyrics?
 - font sizes from several configurations and more.
 - do they want to produce midi, postscript, pdf, mp3, ogg.
 - what tunes do they want to build.
@@ -131,8 +131,8 @@ epdfs:
 - bring more epdfs for the tunes that I already have.
 	document how to find those epdfs.
 - bring the meta data from the epdfs into the database and show them.
-	Where do they come from ? (which real book?).
-	What page ?
+	Where do they come from? (which real book?).
+	What page?
 - support not just the pdf format but other formats as well.
 
 db importing:
@@ -173,10 +173,10 @@ build system
 - add "topic" to each piece. Topics at first should be reflections of the directory
 	the piece is in. Add it to the database.
 - make sure the build system checks that each file has the right tags at the header
-	in the right order (whats the best way to do this ?!?).
+	in the right order (whats the best way to do this?!?).
 - create compressed postscripts and not regular ones (postscript is not a compressed format).
 - make a book with all of the standards.
-	- how do I include all the files ? Should I write a script ?!?
+	- how do I include all the files? Should I write a script?!?
 - make the build system produce a .gitignore file (make the .gitignore file be a target
 	of the build system dependent on everything including the makefile itself).
 - add an option to find lyi files which are not used (not included anywhere).
@@ -191,7 +191,7 @@ outof lilypond lyrics support:
 
 wav support (this is currently disabled):
 =========================================
-- reduce the size of the wav files (why are some of them so big ?!?).
+- reduce the size of the wav files (why are some of them so big?!?).
 	this causes their import to be aborted (this is why it is currently disabled).
 
 mp3 support:
@@ -242,13 +242,13 @@ Info addition
 	Record all of these understandings in some kind of standards document that I will
 	start for all of this material.
 - get number of pages and import that into the database too.
-	How do we get it ?!?
-	- count the number of pages in the pdf (some kind of pdf parser ?!?).
+	How do we get it?!?
+	- count the number of pages in the pdf (some kind of pdf parser?!?).
 	- count the number of images created when --png is used.
 
 Database additions
 ==================
-- get last changed date (the data of the *.ly file ?!?) and put it in the database
+- get last changed date (the data of the *.ly file?!?) and put it in the database
 	on import. Show it in on the web.
 	Enable a direct link to a files history from git from the web.
 - add links to my favourite performances of the tune.

--- a/doc/TODO_tunes.txt
+++ b/doc/TODO_tunes.txt
@@ -2,7 +2,7 @@ Training material:
 ==================
 - write the material for drumming training.
 	get material from the drummers course at Rimon.
-- write hannon and czerny (maybe I can find them on the net ?!?).
+- write hannon and czerny (maybe I can find them on the net?!?).
 - click more rhythms.
                 2 2 , 2 3 , 3 2 , 3 3
 - rock rythms training on splitting 2 bars into pieces:

--- a/doc/coding_style.txt
+++ b/doc/coding_style.txt
@@ -66,7 +66,7 @@ overall song structure:
 - bars
 	Don't do any extra special bars (\bar "||" or the like). It just overloads the music.
 	Mark stuff with \myMark "A", \myMark "B" etc for parts but that's it.
-	At the end of the piece put an ending mark (\bar "|."). My convention is to have this mark at the end of the chords and not the tune. It seems that lilypond does not do that by default. (Why? Is that a bug that I should report ?!?).
+	At the end of the piece put an ending mark (\bar "|."). My convention is to have this mark at the end of the chords and not the tune. It seems that lilypond does not do that by default. (Why? Is that a bug that I should report?!?).
 
 Chords:
 =======

--- a/doc/lilypond_bugs.txt
+++ b/doc/lilypond_bugs.txt
@@ -6,7 +6,7 @@
 the first note of the second (third, forth,...) alternative should have a bow coming into
 it as well. As a side effect this also affects lyrics and midi (midi will play the note twice in the second round and lyrics will put a syllable on it even though it does not deserve one).
 
-- when playing in timidity the channel for the voice is seen as "\new" while the channel for the chords looks like "mychords" (which is the name I gave it). Why is that ?!?
+- when playing in timidity the channel for the voice is seen as "\new" while the channel for the chords looks like "mychords" (which is the name I gave it). Why is that?!?
 
 - When I have a relative tune with the following structure:
 

--- a/doc/lilypond_hints.txt
+++ b/doc/lilypond_hints.txt
@@ -40,7 +40,7 @@ Chords:
 - when you don't want a chord put r if you want N.C. to be printed and s if you
 want nothing to be printed.
 - alternate bass to a chord: c2:m7/bes
-- \chords is akin to \new ChordNames but with something else... What is it ?
+- \chords is akin to \new ChordNames but with something else... What is it?
 	find out from the lilypond documentation...
 - \chords and \chordmode is different. It seems that \chords creates two tracks in midi
 	while \chordmode creates only one. only use \chordmode.
@@ -86,7 +86,7 @@ questions:
 	- <\parenthesize bes:7> does not work
 	- ( bes:7 ) does not work either.
   I have couple of tunes that need this.
-- how do I do 4-3, 9-8 or other similar chords ?
+- how do I do 4-3, 9-8 or other similar chords?
 
 Frets:
 ======
@@ -201,7 +201,7 @@ Lyrics
 	af -- _ _ ter
 	The other way will NOT work:
 	af _ _  -- ter
-	Is this a bug in lilypond ?!?
+	Is this a bug in lilypond?!?
 - broken up word at the end of the tune:
 	Look at "Flamingo" for this. It has the prefix of the last word
 	at the end of the tune and it is supposed to join the suffix of that same word at the begining.
@@ -219,7 +219,7 @@ Midi production
 - if you have multiple scores in one file then you will need multipl \midi statements which
 will lead to multiple midi files produced when that file gets processed.
 
-- Is there a way to catenates all the midi files from within lilypond ? (tell lilypond that all midi should come out in a single midi file ?)
+- Is there a way to catenates all the midi files from within lilypond? (tell lilypond that all midi should come out in a single midi file?)
 
 - setting instruments for midi production
 	list of instruments can be found at
@@ -254,8 +254,8 @@ myMacro={}
 Which seems to work.
 
 Maybe there is a better way?
-	- an official lilypond operation that does nothing ?!?
-	- a scheme macro ?!?
+	- an official lilypond operation that does nothing?!?
+	- a scheme macro?!?
 
 repetitions:
 If you have a repeat which ends EXACTLY where a part ends the \endPart or \bar will trample the special

--- a/doc/lilypond_printing.txt
+++ b/doc/lilypond_printing.txt
@@ -38,7 +38,7 @@ Printing postscript
 ===================
 - You can either use the gnome document viewer or the command line lp(1) (I prefer the latter).
 
-which is better (postscript or pdf) ?
+which is better (postscript or pdf)?
 =====================================
 Postscript:
 	- looks better

--- a/doc/preprocessing.txt
+++ b/doc/preprocessing.txt
@@ -38,7 +38,7 @@ my own preprocessor
 	advantages:
 	- I can have it have any selection of features that I need.
 	disadvantates:
-	- need to be built (C, C++ ?)
+	- need to be built (C, C++?)
 mako
 	advantages:
 	- widely used

--- a/doc/scanning.txt
+++ b/doc/scanning.txt
@@ -1,7 +1,7 @@
 This is a small guide on how to scan in ubuntu
 ==============================================
 
-* why do you need this ?
+* why do you need this?
 because I want to scan real sheet music for reference.
 
 * best program to use.


### PR DESCRIPTION
For some petty reason, the spaces before the question marks in the titles of
the readme were bothering me. I figured I'd fix them and while I was at it,
I greped the .txt docs.

http://english.stackexchange.com/questions/4645/is-it-ever-correct-to-have-a-space-before-a-question-or-exclamation-mark
