### PR TITLE
Fix wrong note in They All Laughed

### DIFF
--- a/src/jazz/they_all_laughed.mako
+++ b/src/jazz/they_all_laughed.mako
@@ -108,7 +108,7 @@
 		r8 d e4 g a | b8.[ b16 a8. g16] a8 b4 g8~ | g1~ | g2. r4 |
 		%% part "A"
 		r8 d e4 g a | b8.[ b16 a8. g16] a8 b4. | d8.[ d16 cis8. b16] cis8 d4 fis,8~ | fis1 |
-		b4 a8. gis16 a8 b4. | b8.[ c16 a8. gis16] a8 b4. | a4 b c b | a d d d |
+		b4 a8. gis16 a8 b4. | b8.[ b16 a8. gis16] a8 b4. | a4 b c b | a d d d |
 		%% part "B"
 		d2~ d8 b4 g8 | a2~ a8.[ b16 c8. cis16] | d4 e d b | c2. b4 |
 		e2~ e8 cis4 a8 | b2~ b8 a4 b8 | c4 e e, g | a1 |


### PR DESCRIPTION
Looks like this was an error in 'Jazz Fakebook' that got copied into Openbook.
I checked three other sources:
- A Frank Sinatra song book
- http://www.danmansmusic.com/members/notation/pdf/23040x.pdf
- http://xa.yimg.com/kq/groups/20774692/911263985/name/George+Gershwin+-+They+All+Laughed.pdf

They all have it as a b. Plus, it seem unlikely to have a c natural against the
c sharp in the chord (A7), which is what got me curious in the first place.
