### PR TITLE
Show half-dim-7th chords as m7b5 instead of circle

### DIFF
--- a/src/include/common.makoi
+++ b/src/include/common.makoi
@@ -104,6 +104,7 @@
 myChordDefinitions={
 	<c ees ges bes des' fes' aes'>-\markup \super {7alt}
 	<c e g bes f'>-\markup \super {7sus}
+	<c ees ges bes>-\markup { "m" \super { "7" \flat "5" } }
 }
 myChordExceptions=#(append
 	(sequential-music-to-chord-exceptions myChordDefinitions #t)


### PR DESCRIPTION
This is obviously a matter of taste so I am simply offering it as a suggestion
to consider. It also may need some tweaking to make it typographically perfect.

As a classical musician I appreciate the brevity and functional implication of
expressing half diminished seventh chords with a slashed circle, but I think it
has a few disadvantages. Here are the reasons I see for adopting the m7b5
style:
1. It's the standard in jazz fakebooks. All but one fakebook I could find used
   some form of the m7b5 notation. (See list below)
2. The slashed circle notation is slightly harder to decipher when sight
   reading. The visual difference between the fully diminished and half
   diminished symbol is sometimes hard to see.

Even if we do want to implement this, it may be worth waiting to merge in this
branch. Currently the flat symbol it renders is slightly larger than the one
for a 7b9 chord. Not sure why that is. I could look into that more deeply if
this fix appeals to you.

Finally, if you don't like this notation, but think others might, we could
think about including it as a compile-time option.
## Survey of notation in other fakebooks

Colorodo: Slashed circle
Bill Evans: m7b(5)
Jazz Fakebook: m7b5
Jazz LTD: m7b(5)
Library of Musician's Jazz: Could not find an example
New Real Book: mi7(b5)
Real Book: -7b5
The Book: -7b5
