### PR TITLE
Make half dim chord notation spacing match 7b9

### DIFF
--- a/src/include/common.makoi
+++ b/src/include/common.makoi
@@ -104,7 +104,7 @@
 myChordDefinitions={
 	<c ees ges bes des' fes' aes'>-\markup \super {7alt}
 	<c e g bes f'>-\markup \super {7sus}
-	<c ees ges bes>-\markup { "m" \super { "7" \flat "5" } }
+	<c ees ges bes>-\markup { "m" \super { "7 " \flat "5" } }
 }
 myChordExceptions=#(append
 	(sequential-music-to-chord-exceptions myChordDefinitions #t)


### PR DESCRIPTION
Lilypond's notation actually has a space between the 7 and the b. I've made our
style match that. A good place to see these two markings side-by-side is the
5th measure of Strange Fruit.
