### PR TITLE
Make the footer that I have point to an openbook web page

### DIFF
--- a/src/include/common.makoi
+++ b/src/include/common.makoi
@@ -670,6 +670,9 @@ Lyricsmoremore=<%include file="/${file}" args="part=Lyricsmoremore"/>
 	\fill-line {
 		\smaller \smaller { "${attributes['tagline']}" }
 	}
+	\fill-line {
+		\smaller \smaller { \with-url #"http://veltzer.net/openbook" http://veltzer.net/openbook }
+	}
 % endif
 }
 


### PR DESCRIPTION
> Make the footer that I have point to an openbook web page that I need to open.
> - Copy the ideas from the mutopia footer.
> 
> (@veltzer) 

I think this is a great idea. I would also like to see a note showing musicians where they can report errors or suggest improvements and encouraging them to do so.
