### PR TITLE
New chord name style is inconsistant

### DIFF
--- a/src/include/common.makoi
+++ b/src/include/common.makoi
@@ -105,9 +105,9 @@ myChordDefinitions={
 	<c ees ges bes des' fes' aes'>-\markup \super {7alt}
 	<c e g bes f'>-\markup \super {7sus}
 	<c ees ges bes>-\markup { "m" \super { "7 " \flat "5" } }
-	<c ees ges beses>-\markup { "dim7" }
+	<c ees ges beses>-\markup { "dim" \super { "7" } }
 	<c ees ges>-\markup { "dim" }
-	<c e g b>-\markup { "maj7" }
+	%%<c e g b>-\markup { "maj7" }
 	<c e gis bes d'>-\markup { \super { "9 " \sharp "5" } }
 }
 myChordExceptions=#(append


### PR DESCRIPTION
I noticed with the new way of notating major 7th chords we have an inconsistency. It is now the only chord that has an "extension" number (7,6,9..) that is not superscript.
1. I tried making just the 7 superscript, but that looked odd because the "maj" looked like it referred to the triad (much like the "m" in "Cm" means a minor triad).
2. I tried making the entire "maj7" superscript, but it looked off balance and too small to read.
3. I tried restyling all the numbers so none of them were superscript and making the entire chord symbol smaller to compensate, and it upset the balance of the entire page.

At this point I feel like going back to the triangle for major seventh chords would be only solution that maintained consistency. Can you think of any other options? Am I overthinking this?

P.S.
The "dim7" chords could use a superscript 7 because the "dim" refers to the triad and would therefore be consistent with "m7".

P.P.S. I have noticed that some fake books include a chord chart showing the basic chords written out in symbols and staff notation for almost every root tone. I think having every bass tone is redundant but it might be nice to have a key to decipher the chord symbols we have chosen to use. -- Maybe we could include a chart of all the different chords having C as their root and show the symbol and staff notation.

When I was first learning to read from fake books I remember being frustrated that there wasn't a reference for all the different chord symbols.

One of the charts I've seen:
![chord_chart_50](https://f.cloud.github.com/assets/162735/1020378/be930ff4-0c95-11e3-9f03-1853ee029d45.jpg)
